### PR TITLE
Support for the Location to be a relative URL

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,6 @@ var (
 	ErrUploadNotFound    = errors.New("upload not found.")
 	ErrResumeNotEnabled  = errors.New("resuming not enabled.")
 	ErrFingerprintNotSet = errors.New("fingerprint not set.")
-	ErrUrlNotRecognized  = errors.New("url not recognized")
 )
 
 type ClientError struct {


### PR DESCRIPTION
The location header value returned by a creation is a URL that
"MAY be absolute or relative" as quoted from the TUS specification:
https://tus.io/protocols/resumable-upload.html#creation

This patch supports the case where the location value is a relative
URL.